### PR TITLE
Update Perplexity API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This is a simple demo website for randomly selecting recipes using the Perplexit
 1. Obtain an API key from Perplexity.
 2. Open `index.html` and enter your API key in the "Perplexity API Key" field.
 
+The script uses Perplexity's latest `v2` API endpoint:
+`https://api.perplexity.ai/v2/recipes/random`.
+
 ## Usage
 
 Serve the project with any static web server (no PHP required), or simply open `index.html` in your browser.

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ document.getElementById('filter-form').addEventListener('submit', async (e) => {
   if (meal) tags.push(meal);
   if (vegetarian) tags.push('vegetarian');
 
-  const url = `https://api.perplexity.ai/recipes/random?tags=${encodeURIComponent(tags.join(','))}`;
+  const url = `https://api.perplexity.ai/v2/recipes/random?tags=${encodeURIComponent(tags.join(','))}`;
 
   try {
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- update API endpoint to Perplexity v2
- document new API endpoint in README

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68519f07a9ec832b883d5fb30ed47275