### PR TITLE
Fix Perplexity API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This is a simple demo website for randomly selecting recipes using the Perplexit
 1. Obtain an API key from Perplexity.
 2. Open `index.html` and enter your API key in the "Perplexity API Key" field.
 
-The script uses Perplexity's latest `v2` API endpoint:
-`https://api.perplexity.ai/v2/recipes/random`.
+The script uses Perplexity's API endpoint:
+`https://api.perplexity.ai/recipes/random`.
 
 ## Usage
 

--- a/script.js
+++ b/script.js
@@ -11,7 +11,7 @@ document.getElementById('filter-form').addEventListener('submit', async (e) => {
   if (meal) tags.push(meal);
   if (vegetarian) tags.push('vegetarian');
 
-  const url = `https://api.perplexity.ai/v2/recipes/random?tags=${encodeURIComponent(tags.join(','))}`;
+  const url = `https://api.perplexity.ai/recipes/random?tags=${encodeURIComponent(tags.join(','))}`;
 
   try {
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- fix Perplexity API URL so requests don't return 404
- update README to document correct endpoint

## Testing
- `node -e "require('./script.js');"` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6851a0de4560832bbe776bf3eb3f467b